### PR TITLE
Implement zeroize on db contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,6 +4851,20 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ thiserror = "1.0.56"
 crypto-common = "0.1.6"
 anyhow = "1.0.75"
 parking_lot = { version = "0.12.1" , features = ["deadlock_detection", "hardware-lock-elision"]}
-zeroize = "1.7.0"
+zeroize = { version="1.7.0", features = ["derive"]}
 
 [dev-dependencies]

--- a/src/db.rs
+++ b/src/db.rs
@@ -26,7 +26,7 @@ pub enum ChangeError {
 	CryptError(#[from] CryptError),
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Zeroize)]
 pub struct DynField {
 	id: usize,
 	kind: DynFieldKind,
@@ -36,7 +36,7 @@ pub struct DynField {
 }
 
 #[derive(
-	Debug, Deserialize, Serialize, Clone, PartialEq, Default, Eq, Hash,
+	Debug, Deserialize, Serialize, Clone, PartialEq, Default, Eq, Hash, Zeroize
 )]
 pub enum DynFieldKind {
 	#[default]
@@ -77,20 +77,20 @@ impl Default for DynField {
 	}
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Zeroize)]
 pub struct DbEntry {
 	pub id: usize,
 	pub title: String,
 	pub fields: Vec<DynField>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Zeroize)]
 pub struct NewDbEntry {
 	pub title: String,
 	pub fields: Vec<DynField>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Zeroize)]
 pub struct DbEntryNonSecure {
 	pub id: usize,
 	pub title: String,
@@ -125,7 +125,7 @@ pub struct DbFileDb {
 	cypher: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Zeroize)]
 struct DbFileCypher {
 	pub contents: Vec<DbEntry>,
 }
@@ -348,7 +348,12 @@ impl Db {
 		*self.db_path.write() = path;
 	}
 
-	pub fn clear_hash(&self) {
+	// fn zeroize_contents(&self) {
+	// 	let contents = self.contents.write();
+	// 	contents.iter().
+	// }
+	pub fn lock(&self) {
+		self.contents.write().zeroize();
 		self.hash.write().zeroize();
 	}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,6 @@ pub fn create_lock_timeout(
 			que.lock.update(|item| item.retain(|ids| *ids != id));
 
 			que.tooltip.set(Vec::new()); // reset all tooltips before locking
-			db_timeout.clear_hash();
 			*db_timeout.vault_unlocked.write() = false;
 			app_state.set(AppState::PassPrompting);
 		}
@@ -167,9 +166,8 @@ fn main() {
 						app_state.set(AppState::Ready);
 					},
 					Err(err) => {
-						eprintln!("{:#?}", err);
+						eprintln!("Failed to decrypt database: {:#?}", err.to_string());
 						error.set(err.to_string());
-						app_state.set(AppState::Ready);
 					},
 				};
 			}
@@ -184,7 +182,7 @@ fn main() {
 				match state {
 					AppState::OnBoarding => onboard_view(password).any(),
 					AppState::PassPrompting => {
-						env.db.clear_hash();
+						env.db.lock();
 						password_view(password, error).any()
 					},
 					AppState::Ready => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,7 @@ pub fn create_lock_timeout(
 			que.lock.update(|item| item.retain(|ids| *ids != id));
 
 			que.tooltip.set(Vec::new()); // reset all tooltips before locking
+			db_timeout.lock();
 			*db_timeout.vault_unlocked.write() = false;
 			app_state.set(AppState::PassPrompting);
 		}
@@ -182,7 +183,6 @@ fn main() {
 				match state {
 					AppState::OnBoarding => onboard_view(password).any(),
 					AppState::PassPrompting => {
-						env.db.lock();
 						password_view(password, error).any()
 					},
 					AppState::Ready => {

--- a/src/ui/app_view.rs
+++ b/src/ui/app_view.rs
@@ -150,7 +150,7 @@ pub fn app_view(
 			},
 			move |_| {
 				tooltip_signals.unque_all_tooltips();
-				db_lock_button.clear_hash();
+				db_lock_button.lock();
 				*db_lock_button.vault_unlocked.write() = false;
 				app_state.set(AppState::PassPrompting);
 			},


### PR DESCRIPTION
Notes:
* Cannot use ZeroizeOnDrop as there are many items that are copied. But since every nested struct derives Zeroize we can just call it on the top object.
* Fixed unlock flow on wrong password/decryption issues.
* Need to dump memory and validate
* Rename `clear_hash` to `lock` so it is `db.lock()` which is much nicer