### PR TITLE
Scoped settings context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,12 +86,12 @@ pub const DEFAULT_DEBUG_PASSWORD: &str = "p";
 pub type TimeoutQueId = RwSignal<u8>;
 
 pub fn create_lock_timeout() {
-	let env: Environment = use_context().expect("No env context provider");
-	let que: Que = use_context().expect("No que context provider");
-	let app_state: RwSignal<AppState> =
-		use_context().expect("No app_state context provider");
-	let timeout_que_id: TimeoutQueId =
-		use_context().expect("No timeout_que_id context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
+	let que = use_context::<Que>().expect("No que context provider");
+	let app_state =
+		use_context::<RwSignal<AppState>>().expect("No app_state context provider");
+	let timeout_que_id =
+		use_context::<TimeoutQueId>().expect("No timeout_que_id context provider");
 
 	let timeout = env.config.general.read().db_timeout;
 	let db_timeout = env.db.clone();

--- a/src/ui/app_view.rs
+++ b/src/ui/app_view.rs
@@ -53,12 +53,12 @@ pub struct ToastSignalsSettings {
 }
 
 pub fn app_view() -> impl View {
-	let env: Environment = use_context().expect("No env context provider");
-	let que: Que = use_context().expect("No que context provider");
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
-	let toast_signals: ToastSignals =
-		use_context().expect("No toast_signals context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
+	let que = use_context::<Que>().expect("No que context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
+	let toast_signals =
+		use_context::<ToastSignals>().expect("No toast_signals context provider");
 
 	let list_sidebar_signal: SidebarList =
 		create_rw_signal(env.db.get_sidebar_list());
@@ -182,8 +182,8 @@ pub fn app_view() -> impl View {
 				..IconButton::default()
 			},
 			move |_| {
-				let app_state: RwSignal<AppState> =
-					use_context().expect("No app_state context provider");
+				let app_state = use_context::<RwSignal<AppState>>()
+					.expect("No app_state context provider");
 
 				que.unque_all_tooltips();
 				db_lock_button.clear_hash();

--- a/src/ui/app_view.rs
+++ b/src/ui/app_view.rs
@@ -38,6 +38,7 @@ pub type SidebarList = RwSignal<im::Vector<(usize, &'static str, usize)>>;
 pub type PresetFieldSignal = RwSignal<PresetFields>;
 pub type QueSettings = Que;
 pub type TooltipSignalsSettings = TooltipSignals;
+pub type ToastSignalsSettings = ToastSignals;
 
 pub fn app_view() -> impl View {
 	let env: Environment = use_context().expect("No env context provider");

--- a/src/ui/app_view.rs
+++ b/src/ui/app_view.rs
@@ -53,11 +53,6 @@ pub struct ToastSignalsSettings {
 }
 
 pub fn app_view() -> impl View {
-	println!(
-		"{:?}, {:?}",
-		std::any::TypeId::of::<QueSettings>(),
-		std::any::TypeId::of::<Que>()
-	);
 	let env: Environment = use_context().expect("No env context provider");
 	let que: Que = use_context().expect("No que context provider");
 	let tooltip_signals: TooltipSignals =

--- a/src/ui/app_view.rs
+++ b/src/ui/app_view.rs
@@ -36,6 +36,8 @@ const SEARCHBAR_HEIGHT: f64 = 30.0;
 
 pub type SidebarList = RwSignal<im::Vector<(usize, &'static str, usize)>>;
 pub type PresetFieldSignal = RwSignal<PresetFields>;
+pub type QueSettings = Que;
+pub type TooltipSignalsSettings = TooltipSignals;
 
 pub fn app_view() -> impl View {
 	let env: Environment = use_context().expect("No env context provider");
@@ -67,8 +69,9 @@ pub fn app_view() -> impl View {
 	let sidebar_scrolled = create_rw_signal(false);
 	let main_scroll_to = create_rw_signal(0.0);
 
-	let que_settings = Que::default();
-	let tooltip_signals_settings = TooltipSignals::new(que_settings);
+	let que_settings: QueSettings = Que::default();
+	let tooltip_signals_settings: TooltipSignalsSettings =
+		TooltipSignals::new(que_settings);
 
 	provide_context(que_settings);
 	provide_context(tooltip_signals_settings);

--- a/src/ui/app_view.rs
+++ b/src/ui/app_view.rs
@@ -36,11 +36,28 @@ const SEARCHBAR_HEIGHT: f64 = 30.0;
 
 pub type SidebarList = RwSignal<im::Vector<(usize, &'static str, usize)>>;
 pub type PresetFieldSignal = RwSignal<PresetFields>;
-pub type QueSettings = Que;
-pub type TooltipSignalsSettings = TooltipSignals;
-pub type ToastSignalsSettings = ToastSignals;
+
+#[derive(Debug, Copy, Clone)]
+pub struct QueSettings {
+	pub inner: Que,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct TooltipSignalsSettings {
+	pub inner: TooltipSignals,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct ToastSignalsSettings {
+	pub inner: ToastSignals,
+}
 
 pub fn app_view() -> impl View {
+	println!(
+		"{:?}, {:?}",
+		std::any::TypeId::of::<QueSettings>(),
+		std::any::TypeId::of::<Que>()
+	);
 	let env: Environment = use_context().expect("No env context provider");
 	let que: Que = use_context().expect("No que context provider");
 	let tooltip_signals: TooltipSignals =
@@ -70,9 +87,12 @@ pub fn app_view() -> impl View {
 	let sidebar_scrolled = create_rw_signal(false);
 	let main_scroll_to = create_rw_signal(0.0);
 
-	let que_settings: QueSettings = Que::default();
-	let tooltip_signals_settings: TooltipSignalsSettings =
-		TooltipSignals::new(que_settings);
+	let que_settings = QueSettings {
+		inner: Que::default(),
+	};
+	let tooltip_signals_settings = TooltipSignalsSettings {
+		inner: TooltipSignals::new(que_settings.inner),
+	};
 
 	provide_context(que_settings);
 	provide_context(tooltip_signals_settings);
@@ -192,7 +212,7 @@ pub fn app_view() -> impl View {
 					},
 					Size::new(500.0, 400.0),
 					move || {
-						que_settings.unque_all_tooltips();
+						que_settings.inner.unque_all_tooltips();
 					},
 				);
 			},

--- a/src/ui/details/button_slots.rs
+++ b/src/ui/details/button_slots.rs
@@ -70,9 +70,9 @@ pub fn edit_button_slot(param: EditButtonSlot) -> impl View {
 		view_button_switch,
 	} = param;
 
-	let env: Environment = use_context().expect("No env context provider");
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let edit_icon = include_str!("../icons/edit.svg");
 	let save_icon = include_str!("../icons/save.svg");
@@ -152,8 +152,8 @@ pub fn view_button_slot(
 		field_value,
 	} = param;
 
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let see_icon = include_str!("../icons/see.svg");
 	let hide_icon = include_str!("../icons/hide.svg");
@@ -191,8 +191,8 @@ pub fn view_button_slot(
 pub fn clipboard_button_slot(
 	getter: impl Fn() -> String + 'static,
 ) -> impl View {
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let clipboard_icon = include_str!("../icons/clipboard.svg");
 
@@ -229,8 +229,8 @@ pub fn history_button_slot(param: HistoryButtonSlot) -> impl View {
 		db,
 	} = param;
 
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let history_icon = include_str!("../icons/history.svg");
 	let hide_history_icon = include_str!("../icons/hide_history.svg");
@@ -316,9 +316,9 @@ pub fn delete_button_slot(param: DeleteButtonSlot) -> impl View {
 		is_hidden,
 	} = param;
 
-	let env: Environment = use_context().expect("No env context provider");
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let delete_icon = include_str!("../icons/delete.svg");
 	let add_icon = include_str!("../icons/add.svg");

--- a/src/ui/details/detail_view.rs
+++ b/src/ui/details/detail_view.rs
@@ -62,9 +62,9 @@ pub fn save_edit(params: SaveEdit) {
 		input_id,
 	} = params;
 
-	let env: Environment = use_context().expect("No env context provider");
-	let list_sidebar_signal: SidebarList =
-		use_context().expect("No list_sidebar_signal context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
+	let list_sidebar_signal = use_context::<SidebarList>()
+		.expect("No list_sidebar_signal context provider");
 
 	let field_value = if is_multiline {
 		String::from(doc.text())
@@ -106,13 +106,13 @@ pub fn save_edit(params: SaveEdit) {
 }
 
 pub fn detail_view(id: usize, main_scroll_to: RwSignal<f32>) -> impl View {
-	let env: Environment = use_context().expect("No env context provider");
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
-	let list_sidebar_signal: SidebarList =
-		use_context().expect("No list_sidebar_signal context provider");
-	let field_presets: PresetFieldSignal =
-		use_context().expect("No field_presets context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
+	let list_sidebar_signal = use_context::<SidebarList>()
+		.expect("No list_sidebar_signal context provider");
+	let field_presets = use_context::<PresetFieldSignal>()
+		.expect("No field_presets context provider");
 
 	let is_overflowing = create_rw_signal(false);
 

--- a/src/ui/details/dyn_field_title_form.rs
+++ b/src/ui/details/dyn_field_title_form.rs
@@ -43,8 +43,8 @@ pub fn dyn_field_title_form(
 		title_input,
 	} = params;
 
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let is_overflow_label = create_rw_signal(false);
 

--- a/src/ui/details/hidden_fields.rs
+++ b/src/ui/details/hidden_fields.rs
@@ -33,8 +33,8 @@ pub fn hidden_fields(param: HiddeFields) -> impl View {
 		main_scroll_to,
 	} = param;
 
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let is_expanded = create_rw_signal(false);
 

--- a/src/ui/details/list_item.rs
+++ b/src/ui/details/list_item.rs
@@ -76,9 +76,9 @@ pub fn list_item(param: ListItem) -> impl View {
 		is_hidden,
 	} = param;
 
-	let env: Environment = use_context().expect("No env context provider");
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let edit_button_switch = create_rw_signal(false);
 	let view_button_switch = create_rw_signal(false);

--- a/src/ui/details/new_field.rs
+++ b/src/ui/details/new_field.rs
@@ -47,9 +47,9 @@ fn save_new_field(params: SaveNewField) {
 		field_list,
 	} = params;
 
-	let env: Environment = use_context().expect("No env context provider");
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let value = match kind.get() {
 		DynFieldKind::Url
@@ -79,8 +79,8 @@ pub fn new_field(
 	field_list: RwSignal<im::Vector<DbFields>>,
 	main_scroll_to: RwSignal<f32>,
 ) -> impl View {
-	let tooltip_signals: TooltipSignals =
-		use_context().expect("No tooltip_signals context provider");
+	let tooltip_signals = use_context::<TooltipSignals>()
+		.expect("No tooltip_signals context provider");
 
 	let show_minus_button = create_rw_signal(false);
 	let preset_value = create_rw_signal(0);

--- a/src/ui/onboard_view.rs
+++ b/src/ui/onboard_view.rs
@@ -35,8 +35,8 @@ fn save(
 }
 
 pub fn onboard_view(password: RwSignal<String>) -> impl View {
-	let toast_signals: ToastSignals =
-		use_context().expect("No toast_signals context provider");
+	let toast_signals =
+		use_context::<ToastSignals>().expect("No toast_signals context provider");
 
 	let new_password_value = create_rw_signal(String::from(""));
 	let repeat_password_value = create_rw_signal(String::from(""));

--- a/src/ui/password_view.rs
+++ b/src/ui/password_view.rs
@@ -19,8 +19,8 @@ use crate::ui::{
 };
 
 pub fn password_view(password: RwSignal<String>) -> impl View {
-	let toast_signals: ToastSignals =
-		use_context().expect("No toast_signals context provider");
+	let toast_signals =
+		use_context::<ToastSignals>().expect("No toast_signals context provider");
 
 	let value = create_rw_signal(String::from(""));
 

--- a/src/ui/settings/database.rs
+++ b/src/ui/settings/database.rs
@@ -18,7 +18,9 @@ use crate::{
 	db::Db,
 	env::Environment,
 	ui::{
-		app_view::{QueSettings, SidebarList, TooltipSignalsSettings},
+		app_view::{
+			QueSettings, SidebarList, ToastSignalsSettings, TooltipSignalsSettings,
+		},
 		colors::*,
 		import::import_view::import_view,
 		primitives::{
@@ -28,7 +30,6 @@ use crate::{
 			que::Que,
 			select::select,
 			styles,
-			toast::ToastSignals,
 		},
 		window_management::{closing_window, opening_window, WindowSpec},
 	},
@@ -123,7 +124,7 @@ pub fn import(
 fn import_window(
 	import_path: RwSignal<Vec<String>>,
 	import_password: RwSignal<String>,
-	toast_signals: ToastSignals,
+	toast_signals: ToastSignalsSettings,
 	env: Environment,
 ) {
 	if !import_path.get().is_empty() {
@@ -167,7 +168,7 @@ pub fn database_view() -> impl View {
 	let que: QueSettings = use_context().expect("No que context provider");
 	let tooltip_signals: TooltipSignalsSettings =
 		use_context().expect("No tooltip_signals context provider");
-	let toast_signals: ToastSignals =
+	let toast_signals: ToastSignalsSettings =
 		use_context().expect("No toast_signals context provider");
 	let env: Environment = use_context().expect("No env context provider");
 

--- a/src/ui/settings/database.rs
+++ b/src/ui/settings/database.rs
@@ -81,8 +81,8 @@ pub fn import(
 	import_db: Db,
 	env: Environment,
 ) {
-	let list_sidebar_signal: SidebarList =
-		use_context().expect("No list_sidebar_signal context provider");
+	let list_sidebar_signal = use_context::<SidebarList>()
+		.expect("No list_sidebar_signal context provider");
 
 	for &(import_id, is_selected) in &import_list {
 		if is_selected {
@@ -174,7 +174,7 @@ pub fn database_view() -> impl View {
 	let toast_signals = use_context::<ToastSignalsSettings>()
 		.expect("No toast_signals context provider")
 		.inner;
-	let env: Environment = use_context().expect("No env context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
 
 	let db_timeout = env.config.general.read().db_timeout;
 	let timeout_backup = create_rw_signal(db_timeout);

--- a/src/ui/settings/database.rs
+++ b/src/ui/settings/database.rs
@@ -30,6 +30,7 @@ use crate::{
 			que::Que,
 			select::select,
 			styles,
+			toast::ToastSignals,
 		},
 		window_management::{closing_window, opening_window, WindowSpec},
 	},
@@ -124,7 +125,7 @@ pub fn import(
 fn import_window(
 	import_path: RwSignal<Vec<String>>,
 	import_password: RwSignal<String>,
-	toast_signals: ToastSignalsSettings,
+	toast_signals: ToastSignals,
 	env: Environment,
 ) {
 	if !import_path.get().is_empty() {
@@ -165,11 +166,14 @@ enum Snap {
 }
 
 pub fn database_view() -> impl View {
-	let que: QueSettings = use_context().expect("No que context provider");
-	let tooltip_signals: TooltipSignalsSettings =
-		use_context().expect("No tooltip_signals context provider");
-	let toast_signals: ToastSignalsSettings =
-		use_context().expect("No toast_signals context provider");
+	let que =
+		use_context::<QueSettings>().expect("No que context provider").inner;
+	let tooltip_signals = use_context::<TooltipSignalsSettings>()
+		.expect("No tooltip_signals context provider")
+		.inner;
+	let toast_signals = use_context::<ToastSignalsSettings>()
+		.expect("No toast_signals context provider")
+		.inner;
 	let env: Environment = use_context().expect("No env context provider");
 
 	let db_timeout = env.config.general.read().db_timeout;

--- a/src/ui/settings/database.rs
+++ b/src/ui/settings/database.rs
@@ -18,7 +18,7 @@ use crate::{
 	db::Db,
 	env::Environment,
 	ui::{
-		app_view::SidebarList,
+		app_view::{QueSettings, SidebarList, TooltipSignalsSettings},
 		colors::*,
 		import::import_view::import_view,
 		primitives::{
@@ -29,7 +29,6 @@ use crate::{
 			select::select,
 			styles,
 			toast::ToastSignals,
-			tooltip::TooltipSignals,
 		},
 		window_management::{closing_window, opening_window, WindowSpec},
 	},
@@ -165,8 +164,8 @@ enum Snap {
 }
 
 pub fn database_view() -> impl View {
-	let que: Que = use_context().expect("No que context provider");
-	let tooltip_signals: TooltipSignals =
+	let que: QueSettings = use_context().expect("No que context provider");
+	let tooltip_signals: TooltipSignalsSettings =
 		use_context().expect("No tooltip_signals context provider");
 	let toast_signals: ToastSignals =
 		use_context().expect("No toast_signals context provider");

--- a/src/ui/settings/editing.rs
+++ b/src/ui/settings/editing.rs
@@ -15,13 +15,12 @@ use crate::{
 	db::DynFieldKind,
 	env::Environment,
 	ui::{
-		app_view::PresetFieldSignal,
+		app_view::{PresetFieldSignal, TooltipSignalsSettings},
 		primitives::{
 			button::{icon_button, IconButton},
 			input_field::input_field,
 			select::select,
 			styles,
-			tooltip::TooltipSignals,
 		},
 	},
 };
@@ -71,7 +70,7 @@ fn preset_line(
 	id: usize,
 	title: String,
 	kind: DynFieldKind,
-	tooltip_signals: TooltipSignals,
+	tooltip_signals: TooltipSignalsSettings,
 	field_presets: RwSignal<PresetFields>,
 	env: Environment,
 ) -> impl View {
@@ -173,7 +172,7 @@ fn preset_line(
 }
 
 pub fn editing_view() -> impl View {
-	let tooltip_signals: TooltipSignals =
+	let tooltip_signals: TooltipSignalsSettings =
 		use_context().expect("No tooltip_signals context provider");
 	let env: Environment = use_context().expect("No env context provider");
 

--- a/src/ui/settings/editing.rs
+++ b/src/ui/settings/editing.rs
@@ -21,6 +21,7 @@ use crate::{
 			input_field::input_field,
 			select::select,
 			styles,
+			tooltip::TooltipSignals,
 		},
 	},
 };
@@ -70,7 +71,7 @@ fn preset_line(
 	id: usize,
 	title: String,
 	kind: DynFieldKind,
-	tooltip_signals: TooltipSignalsSettings,
+	tooltip_signals: TooltipSignals,
 	field_presets: RwSignal<PresetFields>,
 	env: Environment,
 ) -> impl View {
@@ -172,8 +173,9 @@ fn preset_line(
 }
 
 pub fn editing_view() -> impl View {
-	let tooltip_signals: TooltipSignalsSettings =
-		use_context().expect("No tooltip_signals context provider");
+	let tooltip_signals = use_context::<TooltipSignalsSettings>()
+		.expect("No tooltip_signals context provider")
+		.inner;
 	let env: Environment = use_context().expect("No env context provider");
 
 	let field_presets: PresetFieldSignal =

--- a/src/ui/settings/editing.rs
+++ b/src/ui/settings/editing.rs
@@ -176,10 +176,10 @@ pub fn editing_view() -> impl View {
 	let tooltip_signals = use_context::<TooltipSignalsSettings>()
 		.expect("No tooltip_signals context provider")
 		.inner;
-	let env: Environment = use_context().expect("No env context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
 
-	let field_presets: PresetFieldSignal =
-		use_context().expect("No field_presets context provider");
+	let field_presets = use_context::<PresetFieldSignal>()
+		.expect("No field_presets context provider");
 
 	let show_form = create_rw_signal(false);
 	let title_value = create_rw_signal(String::from(""));

--- a/src/ui/settings/general.rs
+++ b/src/ui/settings/general.rs
@@ -12,10 +12,11 @@ use floem::{
 use crate::{
 	env::Environment,
 	ui::{
+		app_view::TooltipSignalsSettings,
 		colors::*,
 		primitives::{
 			button::button, password_field::password_field, styles,
-			toast::ToastSignals, tooltip::TooltipSignals,
+			toast::ToastSignals,
 		},
 	},
 	DEFAULT_DEBUG_PASSWORD,
@@ -54,7 +55,7 @@ fn change_password(
 }
 
 pub fn general_view() -> impl View {
-	let tooltip_signals: TooltipSignals =
+	let tooltip_signals: TooltipSignalsSettings =
 		use_context().expect("No tooltip_signals context provider");
 	let env: Environment = use_context().expect("No env context provider");
 

--- a/src/ui/settings/general.rs
+++ b/src/ui/settings/general.rs
@@ -25,8 +25,9 @@ fn change_password(
 	new_password_check: RwSignal<String>,
 	success: RwSignal<bool>,
 ) {
-	let toast_signals: ToastSignalsSettings =
-		use_context().expect("No toast_signals context provider");
+	let toast_signals = use_context::<ToastSignalsSettings>()
+		.expect("No toast_signals context provider")
+		.inner;
 	let env: Environment = use_context().expect("No env context provider");
 
 	success.set(false);
@@ -52,8 +53,9 @@ fn change_password(
 }
 
 pub fn general_view() -> impl View {
-	let tooltip_signals: TooltipSignalsSettings =
-		use_context().expect("No tooltip_signals context provider");
+	let tooltip_signals = use_context::<TooltipSignalsSettings>()
+		.expect("No tooltip_signals context provider")
+		.inner;
 	let env: Environment = use_context().expect("No env context provider");
 
 	let old_password = create_rw_signal(String::from(""));

--- a/src/ui/settings/general.rs
+++ b/src/ui/settings/general.rs
@@ -12,12 +12,9 @@ use floem::{
 use crate::{
 	env::Environment,
 	ui::{
-		app_view::TooltipSignalsSettings,
+		app_view::{ToastSignalsSettings, TooltipSignalsSettings},
 		colors::*,
-		primitives::{
-			button::button, password_field::password_field, styles,
-			toast::ToastSignals,
-		},
+		primitives::{button::button, password_field::password_field, styles},
 	},
 	DEFAULT_DEBUG_PASSWORD,
 };
@@ -28,7 +25,7 @@ fn change_password(
 	new_password_check: RwSignal<String>,
 	success: RwSignal<bool>,
 ) {
-	let toast_signals: ToastSignals =
+	let toast_signals: ToastSignalsSettings =
 		use_context().expect("No toast_signals context provider");
 	let env: Environment = use_context().expect("No env context provider");
 

--- a/src/ui/settings/general.rs
+++ b/src/ui/settings/general.rs
@@ -28,7 +28,7 @@ fn change_password(
 	let toast_signals = use_context::<ToastSignalsSettings>()
 		.expect("No toast_signals context provider")
 		.inner;
-	let env: Environment = use_context().expect("No env context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
 
 	success.set(false);
 	if new_password.get() != new_password_check.get() {
@@ -56,7 +56,7 @@ pub fn general_view() -> impl View {
 	let tooltip_signals = use_context::<TooltipSignalsSettings>()
 		.expect("No tooltip_signals context provider")
 		.inner;
-	let env: Environment = use_context().expect("No env context provider");
+	let env = use_context::<Environment>().expect("No env context provider");
 
 	let old_password = create_rw_signal(String::from(""));
 	let new_password = create_rw_signal(String::from(""));

--- a/src/ui/settings/settings_view.rs
+++ b/src/ui/settings/settings_view.rs
@@ -7,13 +7,13 @@ use floem::{
 };
 
 use crate::ui::{
+	app_view::{QueSettings, TooltipSignalsSettings},
 	colors::*,
 	primitives::{
 		button::tab_button,
-		que::Que,
 		styles,
 		toast::{toast_view, ToastSignals},
-		tooltip::{tooltip_view, TooltipSignals},
+		tooltip::tooltip_view,
 	},
 	settings::{
 		database::database_view, editing::editing_view, general::general_view,
@@ -43,8 +43,8 @@ impl std::fmt::Display for Tabs {
 pub const TABBAR_HEIGHT: f64 = 63.0;
 
 pub fn settings_view() -> impl View {
-	let que: Que = use_context().expect("No que context provider");
-	let tooltip_signals: TooltipSignals =
+	let que: QueSettings = use_context().expect("No que context provider");
+	let tooltip_signals: TooltipSignalsSettings =
 		use_context().expect("No tooltip_signals context provider");
 
 	let tabs = vec![

--- a/src/ui/settings/settings_view.rs
+++ b/src/ui/settings/settings_view.rs
@@ -7,7 +7,7 @@ use floem::{
 };
 
 use crate::ui::{
-	app_view::{QueSettings, TooltipSignalsSettings},
+	app_view::{QueSettings, ToastSignalsSettings, TooltipSignalsSettings},
 	colors::*,
 	primitives::{
 		button::tab_button,
@@ -63,7 +63,7 @@ pub fn settings_view() -> impl View {
 	let database_icon = include_str!("../icons/database.svg");
 	let shortcut_icon = include_str!("../icons/shortcut.svg");
 
-	let toast_signals = ToastSignals::new(que);
+	let toast_signals: ToastSignalsSettings = ToastSignals::new(que);
 	provide_context(toast_signals);
 
 	let tabs_bar = h_stack((

--- a/src/ui/settings/settings_view.rs
+++ b/src/ui/settings/settings_view.rs
@@ -43,9 +43,11 @@ impl std::fmt::Display for Tabs {
 pub const TABBAR_HEIGHT: f64 = 63.0;
 
 pub fn settings_view() -> impl View {
-	let que: QueSettings = use_context().expect("No que context provider");
-	let tooltip_signals: TooltipSignalsSettings =
-		use_context().expect("No tooltip_signals context provider");
+	let que =
+		use_context::<QueSettings>().expect("No que context provider").inner;
+	let tooltip_signals = use_context::<TooltipSignalsSettings>()
+		.expect("No tooltip_signals context provider")
+		.inner;
 
 	let tabs = vec![
 		Tabs::General,
@@ -63,8 +65,11 @@ pub fn settings_view() -> impl View {
 	let database_icon = include_str!("../icons/database.svg");
 	let shortcut_icon = include_str!("../icons/shortcut.svg");
 
-	let toast_signals: ToastSignalsSettings = ToastSignals::new(que);
+	let toast_signals = ToastSignalsSettings {
+		inner: ToastSignals::new(que),
+	};
 	provide_context(toast_signals);
+	let toast_signals = toast_signals.inner;
 
 	let tabs_bar = h_stack((
 		tab_button(String::from(settings_icon), Tabs::General, tabs, active_tab),

--- a/src/ui/settings/shortcut.rs
+++ b/src/ui/settings/shortcut.rs
@@ -15,9 +15,10 @@ use crate::{
 };
 
 pub fn shortcut_view() -> impl View {
-	let _tooltip_signals: TooltipSignalsSettings =
-		use_context().expect("No tooltip_signals context provider");
-	let _env: Environment = use_context().expect("No env context provider");
+	let _tooltip_signals = use_context::<TooltipSignalsSettings>()
+		.expect("No tooltip_signals context provider")
+		.inner;
+	let _env = use_context::<Environment>().expect("No env context provider");
 
 	// TODO: add shortcut settings
 	container(

--- a/src/ui/settings/shortcut.rs
+++ b/src/ui/settings/shortcut.rs
@@ -9,12 +9,13 @@ use crate::{
 	env::Environment,
 	ui::{
 		// colors::*,
-		primitives::{styles, tooltip::TooltipSignals},
+		app_view::TooltipSignalsSettings,
+		primitives::styles,
 	},
 };
 
 pub fn shortcut_view() -> impl View {
-	let _tooltip_signals: TooltipSignals =
+	let _tooltip_signals: TooltipSignalsSettings =
 		use_context().expect("No tooltip_signals context provider");
 	let _env: Environment = use_context().expect("No env context provider");
 


### PR DESCRIPTION
Wrapping contexts that share types with other contexts whilst floem does not support namespaces. 
This fixes an issue where contexts were being overwritten and lost when they went out of scope, causing the program to panic when the original context was being called. 