### PR TITLE
removed dyn scrolls

### DIFF
--- a/src/ui/details/detail_view.rs
+++ b/src/ui/details/detail_view.rs
@@ -36,7 +36,7 @@ pub const SECRET_MULTILINE_PLACEHOLDER: &str =
 pub const INPUT_LINE_WIDTH: f64 = 250.0;
 pub const LABEL_WIDTH: f64 = 142.0;
 pub const LINE_WIDTH: f64 = 560.0;
-pub const MULTILINE_HEIGHT: f64 = 170.0;
+pub const MULTILINE_HEIGHT: f64 = 175.0;
 pub const DETAILS_MIN_WIDTH: f64 = 600.0;
 
 pub struct SaveEdit {

--- a/src/ui/details/detail_view.rs
+++ b/src/ui/details/detail_view.rs
@@ -36,7 +36,7 @@ pub const SECRET_MULTILINE_PLACEHOLDER: &str =
 pub const INPUT_LINE_WIDTH: f64 = 250.0;
 pub const LABEL_WIDTH: f64 = 142.0;
 pub const LINE_WIDTH: f64 = 560.0;
-pub const MULTILINE_HEIGHT: f64 = 175.0;
+pub const MULTILINE_HEIGHT: f64 = 165.0;
 pub const DETAILS_MIN_WIDTH: f64 = 600.0;
 
 pub struct SaveEdit {

--- a/src/ui/details/list_item.rs
+++ b/src/ui/details/list_item.rs
@@ -412,7 +412,7 @@ pub fn list_item(param: ListItem) -> impl View {
 						.display(Display::Flex)
 						.apply_if(edit_button_switch.get(), |s| s.display(Display::None))
 						.apply_if(is_multiline, |s| {
-							s.height(MULTILINE_HEIGHT)
+							s.line_height(1.0)
 								.border_left(BORDER_WIDTH)
 								.padding_right(0)
 								.border_bottom(0)

--- a/src/ui/details/list_item.rs
+++ b/src/ui/details/list_item.rs
@@ -398,39 +398,41 @@ pub fn list_item(param: ListItem) -> impl View {
 		),
 		h_stack((
 			input_line,
-			scroll(label(move || replace_consecutive_newlines(field_value.get())))
-				.style(move |s| {
-					s.flex_grow(1.0)
-						.width_full()
-						.padding_top(5)
-						.padding_right(6)
-						.padding_left(6)
-						.padding_bottom(5)
-						.border_bottom(1)
-						.border_color(C_TOP_TEXT)
-						.apply_if(is_hidden, |s| s.border_color(C_MAIN_TEXT_INACTIVE))
-						.display(Display::Flex)
-						.apply_if(edit_button_switch.get(), |s| s.display(Display::None))
-						.apply_if(is_multiline, |s| {
-							s.line_height(1.0)
-								.border_left(BORDER_WIDTH)
-								.padding_right(0)
-								.border_bottom(0)
-								.margin_right(-7)
+			scroll(
+				label(move || replace_consecutive_newlines(field_value.get()))
+					.style(|s| s.font_family(String::from("Monospace"))),
+			)
+			.style(move |s| {
+				s.flex_grow(1.0)
+					.width_full()
+					.padding_top(5)
+					.padding_right(6)
+					.padding_left(6)
+					.padding_bottom(5)
+					.border_bottom(1)
+					.border_color(C_TOP_TEXT)
+					.apply_if(is_hidden, |s| s.border_color(C_MAIN_TEXT_INACTIVE))
+					.display(Display::Flex)
+					.apply_if(edit_button_switch.get(), |s| s.display(Display::None))
+					.apply_if(is_multiline, |s| {
+						s.height(MULTILINE_HEIGHT)
+							.border_left(BORDER_WIDTH)
+							.padding_right(0)
+							.border_bottom(0)
+							.margin_right(-7)
+					})
+					.hover(|s| {
+						s.apply_if(is_url_field, |s| {
+							s.color(C_FOCUS).cursor(CursorStyle::Pointer)
 						})
-						.hover(|s| {
-							s.apply_if(is_url_field, |s| {
-								s.color(C_FOCUS).cursor(CursorStyle::Pointer)
-							})
-						})
-				})
-				.on_click_cont(move |_| {
-					if is_url_field {
-						let _ = webbrowser::open(&url_escape::encode_fragment(
-							&field_value.get(),
-						));
-					}
-				}),
+					})
+			})
+			.on_click_cont(move |_| {
+				if is_url_field {
+					let _ =
+						webbrowser::open(&url_escape::encode_fragment(&field_value.get()));
+				}
+			}),
 		))
 		.style(|s| s.width(INPUT_LINE_WIDTH)),
 		edit_button_slot(EditButtonSlot {

--- a/src/ui/details/list_item.rs
+++ b/src/ui/details/list_item.rs
@@ -9,7 +9,7 @@ use floem::{
 	style::{AlignItems, CursorStyle, Display, Position},
 	view::View,
 	views::{
-		container, dyn_container,
+		container,
 		editor::core::{editor::EditType, selection::Selection},
 		empty, h_stack, label, scroll, Decorators,
 	},
@@ -398,49 +398,41 @@ pub fn list_item(param: ListItem) -> impl View {
 		),
 		h_stack((
 			input_line,
-			dyn_container(
-				move || field_value.get(),
-				move |value| {
-					if value.lines().count() > 11 {
-						scroll(label(move || {
-							replace_consecutive_newlines(field_value.get())
-						}))
-						.style(|s| s.width_full())
-						.any()
-					} else {
-						label(move || replace_consecutive_newlines(field_value.get())).any()
-					}
-				},
-			)
-			.style(move |s| {
-				s.width(INPUT_LINE_WIDTH)
-					.padding_top(5)
-					.padding_right(6)
-					.padding_left(6)
-					.padding_bottom(5)
-					.border_bottom(1)
-					.border_color(C_TOP_TEXT)
-					.apply_if(is_hidden, |s| s.border_color(C_MAIN_TEXT_INACTIVE))
-					.display(Display::Flex)
-					.apply_if(edit_button_switch.get(), |s| s.display(Display::None))
-					.apply_if(is_multiline, |s| {
-						s.height(MULTILINE_HEIGHT)
-							.border_left(BORDER_WIDTH)
-							.border_bottom(0)
-					})
-					.hover(|s| {
-						s.apply_if(is_url_field, |s| {
-							s.color(C_FOCUS).cursor(CursorStyle::Pointer)
+			scroll(label(move || replace_consecutive_newlines(field_value.get())))
+				.style(move |s| {
+					s.flex_grow(1.0)
+						.width_full()
+						.padding_top(5)
+						.padding_right(6)
+						.padding_left(6)
+						.padding_bottom(5)
+						.border_bottom(1)
+						.border_color(C_TOP_TEXT)
+						.apply_if(is_hidden, |s| s.border_color(C_MAIN_TEXT_INACTIVE))
+						.display(Display::Flex)
+						.apply_if(edit_button_switch.get(), |s| s.display(Display::None))
+						.apply_if(is_multiline, |s| {
+							s.height(MULTILINE_HEIGHT)
+								.border_left(BORDER_WIDTH)
+								.padding_right(0)
+								.border_bottom(0)
+								.margin_right(-7)
 						})
-					})
-			})
-			.on_click_cont(move |_| {
-				if is_url_field {
-					let _ =
-						webbrowser::open(&url_escape::encode_fragment(&field_value.get()));
-				}
-			}),
-		)),
+						.hover(|s| {
+							s.apply_if(is_url_field, |s| {
+								s.color(C_FOCUS).cursor(CursorStyle::Pointer)
+							})
+						})
+				})
+				.on_click_cont(move |_| {
+					if is_url_field {
+						let _ = webbrowser::open(&url_escape::encode_fragment(
+							&field_value.get(),
+						));
+					}
+				}),
+		))
+		.style(|s| s.width(INPUT_LINE_WIDTH)),
 		edit_button_slot(EditButtonSlot {
 			id,
 			field,

--- a/src/ui/history_view.rs
+++ b/src/ui/history_view.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 
 const HISTORY_LINE_HEIGHT: f64 = 31.0;
+const PADDING: f64 = 10.0;
 
 fn history_line(
 	idx: usize,
@@ -82,14 +83,17 @@ fn history_line(
 		container(
 			scroll(
 				label(move || replace_consecutive_newlines(field_value.get().clone()))
+					.style(|s| s.font_family(String::from("Monospace")))
 					.style(move |s| {
-						s.apply_if(is_multiline, |s| s.padding_top(10).padding_bottom(10))
+						s.apply_if(is_multiline, |s| {
+							s.padding_top(PADDING).padding_bottom(PADDING)
+						})
 					}),
 			)
 			.style(move |s| {
 				s.flex_grow(1.0)
 					.width(80)
-					.apply_if(is_multiline, |s| s.line_height(1.0))
+					.apply_if(is_multiline, |s| s.height(MULTILINE_HEIGHT + PADDING))
 			}),
 		)
 		.any()
@@ -111,9 +115,9 @@ fn history_line(
 			.width_full()
 			.max_width_full()
 			.height(HISTORY_LINE_HEIGHT)
-			.apply_if(is_multiline, |s| s.height(MULTILINE_HEIGHT))
+			.apply_if(is_multiline, |s| s.height(MULTILINE_HEIGHT + PADDING))
 			.gap(4.0, 0.0)
-			.padding_horiz(10)
+			.padding_horiz(PADDING)
 			.items_center()
 			.class(scroll::Handle, styles::scrollbar_styles)
 			.background(if let 0 = idx % 2 {
@@ -145,7 +149,7 @@ pub fn history_view(
 						db_height.get_field_kind(&id, &field),
 						DynFieldKind::MultiLine | DynFieldKind::MultiLineSecret
 					) {
-						MULTILINE_HEIGHT
+						MULTILINE_HEIGHT + PADDING
 					} else {
 						HISTORY_LINE_HEIGHT
 					}

--- a/src/ui/history_view.rs
+++ b/src/ui/history_view.rs
@@ -6,8 +6,8 @@ use floem::{
 	reactive::create_rw_signal,
 	view::View,
 	views::{
-		container, dyn_container, h_stack, label, scroll, virtual_stack,
-		Decorators, VirtualDirection, VirtualItemSize,
+		container, h_stack, label, scroll, virtual_stack, Decorators,
+		VirtualDirection, VirtualItemSize,
 	},
 };
 
@@ -79,37 +79,21 @@ fn history_line(
 			.on_event_cont(EventListener::PointerLeave, move |_| {
 				tooltip_signals.hide();
 			}),
-		dyn_container(
-			move || (view_button_switch.get(), field_value.get()),
-			move |(switch, value)| {
-				let value_with_lines = replace_consecutive_newlines(value);
-
-				match switch {
-					// Show secret data
-					true => container(
-						scroll(label(move || value_with_lines.clone()).style(move |s| {
-							s.apply_if(is_multiline, |s| s.padding_top(10).padding_bottom(10))
-						}))
-						.style(move |s| {
-							s.flex_grow(1.0)
-								.width(80)
-								.apply_if(is_multiline, |s| s.height(MULTILINE_HEIGHT))
-						}),
-					)
-					.any()
-					.style(|s| s.flex_grow(1.0).width(80)),
-					// Show placeholder
-					false => label(move || value_with_lines.clone())
-						.style(move |s| {
-							s.flex_grow(1.0).apply_if(is_multiline, |s| {
-								s.height(MULTILINE_HEIGHT).padding_top(10)
-							})
-						})
-						.any(),
-				}
-			},
+		container(
+			scroll(
+				label(move || replace_consecutive_newlines(field_value.get().clone()))
+					.style(move |s| {
+						s.apply_if(is_multiline, |s| s.padding_top(10).padding_bottom(10))
+					}),
+			)
+			.style(move |s| {
+				s.flex_grow(1.0)
+					.width(80)
+					.apply_if(is_multiline, |s| s.height(MULTILINE_HEIGHT))
+			}),
 		)
-		.style(|s| s.flex_grow(1.0)),
+		.any()
+		.style(|s| s.flex_grow(1.0).width(80)),
 		view_button_slot(
 			ViewButtonSlot {
 				switch: view_button_switch,

--- a/src/ui/history_view.rs
+++ b/src/ui/history_view.rs
@@ -89,7 +89,7 @@ fn history_line(
 			.style(move |s| {
 				s.flex_grow(1.0)
 					.width(80)
-					.apply_if(is_multiline, |s| s.height(MULTILINE_HEIGHT))
+					.apply_if(is_multiline, |s| s.line_height(1.0))
 			}),
 		)
 		.any()

--- a/src/ui/primitives/button.rs
+++ b/src/ui/primitives/button.rs
@@ -170,8 +170,8 @@ pub fn icon_button(
 		)),))
 		.style(move |s| {
 			s.position(Position::Absolute)
-				.inset_top(0)
-				.inset_right(0)
+				.inset_top(1)
+				.inset_right(1)
 				.apply_if(is_tiny, |s| s.inset_top(-3).inset_right(-5))
 		})
 	} else {

--- a/vault_db.toml
+++ b/vault_db.toml
@@ -1168,6 +1168,19 @@ line 2
 line 3
 
 line 5
+end\"\"\"], [1710878163, \"\"\"
+line 1
+line 2
+line 3
+
+line 5
+
+
+
+
+
+
+
 end\"\"\"]]
 
 [[contents.fields]]


### PR DESCRIPTION
Since lapce/floem#80 has been shipped we now don't need to wrap `scroll` into `dyn_containers` to make scrolling work so this is the work to undo this.
Added a bit of space to the non-secret notes field so we can test it