### PR TITLE
tweaking the list items

### DIFF
--- a/src/ui/details/list_item.rs
+++ b/src/ui/details/list_item.rs
@@ -162,8 +162,11 @@ pub fn list_item(param: ListItem) -> impl View {
 					tooltip_signals.hide();
 				},
 			)
-			.style(|s| {
-				s.position(Position::Absolute).inset_top(0).inset_right(-27 - 5)
+			.style(move |s| {
+				s.position(Position::Absolute)
+					.inset_top(0)
+					.inset_right(-27 - 5 - 5)
+					.apply_if(is_secret, |s| s.inset_right(-27 - 5))
 			}),
 		))
 		.style(|s| s.position(Position::Relative))
@@ -403,28 +406,21 @@ pub fn list_item(param: ListItem) -> impl View {
 		h_stack((
 			input_line,
 			scroll(
-				label(move || replace_consecutive_newlines(field_value.get()))
-					.style(|s| s.font_family(String::from("Monospace"))),
+				label(move || replace_consecutive_newlines(field_value.get())).style(
+					|s| s.padding_bottom(3).font_family(String::from("Monospace")),
+				),
 			)
 			.style(move |s| {
 				s.flex_grow(1.0)
 					.width_full()
-					.padding_top(5)
-					.padding_right(6)
-					.padding_left(6)
-					.padding_bottom(5)
-					.border_bottom(1)
+					.margin_left(5)
+					.margin_right(5)
+					.border_bottom(BORDER_WIDTH)
 					.border_color(C_TOP_TEXT)
 					.apply_if(is_hidden, |s| s.border_color(C_MAIN_TEXT_INACTIVE))
 					.display(Display::Flex)
 					.apply_if(edit_button_switch.get(), |s| s.display(Display::None))
-					.apply_if(is_multiline, |s| {
-						s.height(MULTILINE_HEIGHT)
-							.border_left(BORDER_WIDTH)
-							.padding_right(0)
-							.border_bottom(0)
-							.margin_right(-7)
-					})
+					.apply_if(is_multiline, |s| s.height(MULTILINE_HEIGHT))
 					.hover(|s| {
 						s.apply_if(is_url_field, |s| {
 							s.color(C_FOCUS).cursor(CursorStyle::Pointer)


### PR DESCRIPTION
| Before | After |
|--|--|
| <img width="912" alt="image" src="https://github.com/dominikwilkowski/vault/assets/1266923/bce09dd6-7c9e-4028-a44a-af0ac4a88c79"> | <img width="912" alt="image" src="https://github.com/dominikwilkowski/vault/assets/1266923/207bff69-452d-400c-8d5d-b9d0e65a4e37"> |
| <img width="912" alt="image" src="https://github.com/dominikwilkowski/vault/assets/1266923/7f52ff7b-b7c0-44c7-83ad-bb52a840712c"> | <img width="912" alt="image" src="https://github.com/dominikwilkowski/vault/assets/1266923/7cfa194c-ce19-42d4-bf0c-cfce00394277"> |

Less visual noise and I never really liked that vertical line on multi line fields... be gone!