### PR TITLE
History values are reversed from history dates

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -563,7 +563,6 @@ impl Db {
 				.get_field_by_id(&entry, field_id)
 				.value
 				.into_iter()
-				.rev()
 				.collect::<Vec<SecureField>>()[n]
 				.1
 				.clone(),

--- a/src/db.rs
+++ b/src/db.rs
@@ -563,6 +563,7 @@ impl Db {
 				.get_field_by_id(&entry, field_id)
 				.value
 				.into_iter()
+				.rev()
 				.collect::<Vec<SecureField>>()[n]
 				.1
 				.clone(),
@@ -606,6 +607,7 @@ impl Db {
 				.get_field_by_id(&entry, field_id)
 				.value
 				.iter()
+				.rev()
 				.map(|item| item.0)
 				.enumerate()
 				.collect(),


### PR DESCRIPTION
The dates of the history view are from oldest to newest but the values were newest to oldest. 

There is a .rev in `get_n_by_field`. I am not sure of its purpose, maybe we want dates and this reversed to have both newest to oldest? So a rev should be added to `get_history_dates`.

This is for discussion and fix.